### PR TITLE
Change how urls are saved in trrrace.json

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,10 @@ const migrateTrrraceFormat = (projectData) => {
     ...projectData,
     entries: projectData.entries.map((e) => ({
       ...e,
-      urls: e.urls ? e.urls : [],
+      files: [
+        ...e.files,
+        ...e.urls.map((u) => ({ title: u.title, url: u.url, fileType: 'url' })),
+      ],
       tags: e.tags.map((t) => (typeof t === 'string' ? t : t.text)),
     })),
   };

--- a/src/components/Entry.tsx
+++ b/src/components/Entry.tsx
@@ -120,6 +120,9 @@ const Entry = (props: EntryPropTypes) => {
     enter: 13,
   };
 
+  const urls = entryData.files.filter((f) => f.fileType === 'url');
+  const files = entryData.files.filter((f) => f.fileType !== 'url');
+
   return (
     <>
       <h3>
@@ -174,7 +177,7 @@ const Entry = (props: EntryPropTypes) => {
       )}
 
       <ul>
-        {entryData.files.map((file: File) => (
+        {files.map((file: File) => (
           <li key={file.title}>
             {file.title}{' '}
             <FaExternalLinkAlt
@@ -213,7 +216,9 @@ const Entry = (props: EntryPropTypes) => {
         </button>
       )}
 
-      <URLList urls={entryData.urls} entryIndex={entryIndex} />
+      <br />
+
+      <URLList urls={urls} entryIndex={entryIndex} />
 
       <></>
     </>

--- a/src/components/ProjectContext.tsx
+++ b/src/components/ProjectContext.tsx
@@ -138,13 +138,14 @@ const appStateReducer = (state, action) => {
     }
 
     case 'ADD_URL': {
+      let newFiles = state.projectData.entries[action.entryIndex].files;
+      newFiles = [
+        ...newFiles,
+        { title: action.title, url: action.url, fileType: 'url' },
+      ];
+
       const entries = state.projectData.entries.map((d: EntryType, i: number) =>
-        action.entryIndex === i
-          ? {
-              ...d,
-              urls: [...d.urls, { url: action.url, title: action.title }],
-            }
-          : d
+        action.entryIndex === i ? { ...d, files: newFiles } : d
       );
 
       const newProjectData = { ...state.projectData, entries };

--- a/src/components/ReadonlyEntry.tsx
+++ b/src/components/ReadonlyEntry.tsx
@@ -14,6 +14,9 @@ interface EntryPropTypes {
 const ReadonlyEntry = (props: EntryPropTypes) => {
   const { entryData, openFile, makeEditable } = props;
 
+  const urls = entryData.files.filter((f) => f.fileType === 'url');
+  const files = entryData.files.filter((f) => f.fileType !== 'url');
+
   return (
     <>
       <h3>
@@ -36,7 +39,7 @@ const ReadonlyEntry = (props: EntryPropTypes) => {
       <p>Tags: {entryData.tags.join(', ')}</p>
       <p>{entryData.description}</p>
       <ul>
-        {entryData.files.map((file: File) => (
+        {files.map((file: File) => (
           <li key={file.title}>
             {file.title}{' '}
             <FaExternalLinkAlt
@@ -48,11 +51,11 @@ const ReadonlyEntry = (props: EntryPropTypes) => {
         ))}
       </ul>
 
-      {entryData.urls.length > 0 && (
+      {urls.length > 0 && (
         <>
           <h3>URLs</h3>
           <ul>
-            {entryData.urls.map((url) => (
+            {urls.map((url) => (
               <li key={url.url}>
                 <a href={url.url}>{url.title}</a>
               </li>

--- a/src/components/types.tsx
+++ b/src/components/types.tsx
@@ -1,7 +1,9 @@
 // files
 
 interface File {
+  fileType: string;
   title: string;
+  url?: string;
 }
 
 interface FileObj {


### PR DESCRIPTION
Rather than separate arrays for files and URLs, store them both in a single array, with an attribute recording their type.

This is consistent with @jrogerthat's  implementation, which better handles *multiple* attachment types (local files, files in Google Docs, and URLs).