### PR TITLE
Screenshot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ipcRenderer } from 'electron';
 
 import Project from './components/Project';
 import Splash from './components/Splash';
+import Screenshot from './components/Screenshot';
 
 import './App.global.css';
 
@@ -37,6 +38,9 @@ export default function App() {
   const [noProjectSelected, setNoProjectSelected] = useState<boolean>(false);
   const [recentPaths, setRecentPaths] = useState<string[]>([]);
 
+  const [screenshotEntryId, setScreenshotEntryId] =
+    useState<false | number>(false);
+
   ipcRenderer.on('projectPath', (_event, folderName) => {
     console.log('Received project path:', folderName);
 
@@ -57,10 +61,23 @@ export default function App() {
     });
   });
 
+  ipcRenderer.on('configScreenshot', (_event, folderName, entryId) => {
+    setPath(folderName);
+    setScreenshotEntryId(entryId);
+  });
+
   ipcRenderer.on('noProjectSelected', (_event, newRecentPaths) => {
     setNoProjectSelected(true);
     setRecentPaths(newRecentPaths);
   });
+
+  if (screenshotEntryId) {
+    return (
+      <ChakraProvider>
+        <Screenshot folderPath={folderPath} entryIndex={screenshotEntryId} />
+      </ChakraProvider>
+    );
+  }
 
   if (noProjectSelected) {
     return (

--- a/src/components/Entry.tsx
+++ b/src/components/Entry.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Heading, ListItem, UnorderedList } from '@chakra-ui/react';
 
+import { ipcRenderer } from 'electron';
+
 import DatePicker from 'react-datepicker';
 import EdiText from 'react-editext';
 import ReactMde from 'react-mde';
-import { FaExternalLinkAlt, FaPlus, FaTrashAlt } from 'react-icons/fa';
+import {
+  FaCamera,
+  FaExternalLinkAlt,
+  FaPlus,
+  FaTrashAlt,
+} from 'react-icons/fa';
 
 import { WithContext as ReactTags } from 'react-tag-input';
 
@@ -219,6 +226,10 @@ const Entry = (props: EntryPropTypes) => {
           <FaPlus /> Add files
         </Button>
       )}
+
+      <Button onClick={() => ipcRenderer.send('takeScreenshot', entryIndex)}>
+        <FaCamera /> Take screenshot
+      </Button>
 
       <br />
 

--- a/src/components/ReadonlyEntry.tsx
+++ b/src/components/ReadonlyEntry.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import { Heading, ListItem, Tag, Text, UnorderedList } from '@chakra-ui/react';
 import { EditIcon } from '@chakra-ui/icons';
-
 import { FaExternalLinkAlt } from 'react-icons/fa';
+
 import { format } from 'date-fns';
+import * as Showdown from 'showdown';
 
 import { File, EntryType, TagType } from './types';
 import textColor from '../colors';
@@ -33,6 +34,13 @@ const ReadonlyEntry = (props: EntryPropTypes) => {
     }
     return matchingTags[0].color;
   };
+
+  const converter = new Showdown.Converter({
+    tables: true,
+    simplifiedAutoLink: true,
+    strikethrough: true,
+    tasklists: true,
+  });
 
   return (
     <>
@@ -69,7 +77,11 @@ const ReadonlyEntry = (props: EntryPropTypes) => {
 
       <br />
 
-      <p>{entryData.description}</p>
+      <div
+        dangerouslySetInnerHTML={{
+          __html: converter.makeHtml(entryData.description),
+        }}
+      />
 
       <UnorderedList>
         {files.map((file: File) => (

--- a/src/components/Screenshot.tsx
+++ b/src/components/Screenshot.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Button, FormControl, FormLabel, Input } from '@chakra-ui/react';
+import { FaCamera } from 'react-icons/fa';
+
+const Screenshot = ({ folderPath, entryIndex }) => {
+  const [fileName, setFileName] = useState<string>(new Date().toISOString());
+
+  // Can find the [display](https://www.electronjs.org/docs/v14-x-y/api/structures/display) object a window is on.
+  // Should be able to match with the [DesktopCapturerSource](https://www.electronjs.org/docs/latest/api/structures/desktop-capturer-source) using the `display_id` attribute, but it is [empty on linux](https://github.com/electron/electron/issues/27732)
+  // so we can let the user select which region to screenshot, but don't know which screen they mean.
+  // could ake a screenshot for each, and let them choose?
+
+  const onSnipClick = async () => {
+    const { desktopCapturer, remote } = window.require('electron');
+    const path = window.require('path');
+    const fs = window.require('fs');
+
+    const currentWindow = remote.getCurrentWindow();
+    const windowBounds = currentWindow.getBounds();
+
+    // win.hide();
+
+    try {
+      const currentScreen = remote.screen.getDisplayNearestPoint({
+        x: windowBounds.x,
+        y: windowBounds.y,
+      });
+
+      // TODO: should use current_screen, not the primary display
+      const screenSize = remote.screen.getPrimaryDisplay().workAreaSize;
+      const maxDimension = Math.max(screenSize.width, screenSize.height);
+
+      const sources = await desktopCapturer.getSources({
+        types: ['screen'],
+        thumbnailSize: {
+          width: maxDimension * window.devicePixelRatio,
+          height: maxDimension * window.devicePixelRatio,
+        },
+      });
+
+      const source = sources.find(
+        (s) => s.name === 'Entire Screen' || s.name === 'Screen 1'
+      );
+
+      if (source) {
+        const image = source.thumbnail
+          .resize({
+            width: screenSize.width,
+            height: screenSize.height,
+          })
+          .crop(windowBounds)
+          .toPNG();
+
+        const outputPath = path.join(folderPath, `${fileName}.png`);
+        fs.writeFile(
+          outputPath,
+          image,
+          (err: Error) => err && console.error(err)
+        );
+      } else {
+        window.alert('Source not found.');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <>
+      <FormControl>
+        <FormLabel>Filename: </FormLabel>
+        <Input
+          value={fileName}
+          onChange={(ev) => setFileName(ev.target.value)}
+        />
+      </FormControl>
+      <Button onClick={onSnipClick}>
+        <FaCamera /> Save screenshot
+      </Button>
+      {folderPath}, {entryIndex}
+    </>
+  );
+};
+
+export default Screenshot;


### PR DESCRIPTION
This only works partially - if a user has multiple monitors, it can't tell which monitor it should be taking a screenshot of.

There are a few possible work-arounds:

- tell the user that they can only take screenshots of the Primary Display
- take a screenshot from the selected region of every display, then show these to the user and ask the user which one they wanted (save to a temp folder, display in the screenshot window, and then copy the selected one to the project window)
- take a screenshot of each display, show the user thumbnails, and ask the user to select one before taking the screenshot